### PR TITLE
Fix broken repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "icon": "media/icon.png",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VincenzoManto/dev-diary"
+    "url": "https://github.com/VincenzoManto/DevDiary"
   },
   "engines": {
     "vscode": "^1.102.0"


### PR DESCRIPTION
The repository URL of the published extension contains a broken URL reference, rendering the Repository, Issues and Homepage links broken on the Visual Studio Marketplace. The project details link is affected as well.

GitHub should handle repository name changes with redirects but for some reason, in this case, it does not.

Fixes #1